### PR TITLE
Adding context to price call on cart add promotion

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -93,11 +93,7 @@ class Cart
 		foreach ($items as $item) {
 			while ($item) {
 				$discount = $promotion->getQualifiedItemDiscount($item, $this);
-				$price    = $this->price($item, 0, [__FUNCTION__ => $discount]);
-
-				if ($discount > $price) {
-					$discount = $price;
-				}
+				$price    = $this->price();
 
 				if ($discount) {
 					$item->setItemDiscount($promo_key, $discount * -1);

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -93,7 +93,7 @@ class Cart
 		foreach ($items as $item) {
 			while ($item) {
 				$discount = $promotion->getQualifiedItemDiscount($item, $this);
-				$price    = $this->price();
+				$price    = $this->price($item);
 
 				if ($discount) {
 					$item->setItemDiscount($promo_key, $discount * -1);

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -93,7 +93,7 @@ class Cart
 		foreach ($items as $item) {
 			while ($item) {
 				$discount = $promotion->getQualifiedItemDiscount($item, $this);
-				$price    = $this->price($item);
+				$price    = $this->price($item, 0, [__FUNCTION__ => $discount]);
 
 				if ($discount > $price) {
 					$discount = $price;


### PR DESCRIPTION
addPromotion needs the discount context when deciding how much the discount should be.  This is relevant for discounting a partial amount of the item price.